### PR TITLE
Use 'new' with sdk/net/xhr XMLHttpRequest

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -90,7 +90,7 @@ function parseGmailFeed(xmlDoc) {
 }
 
 function requestGmailFeed() {
-	let request = xhr.XMLHttpRequest();
+	let request = new xhr.XMLHttpRequest();
 	request.onreadystatechange = function() {
 		if (request.readyState === 4) {
 			if (request.status === 200) {


### PR DESCRIPTION
I couldn't get this addon to work so I went into about:addons and ran the debugger and saw some error saying that the `XMLHttpRequest` object from `sdk/xhr` needs to be instantiated with `new`. I edited the source of the extension directly in my profile folder and restarted the browser - lo and behold, it works!
